### PR TITLE
Set TS build target to ES5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
-    "target": "ES6",
+    "target": "ES5",
     "declaration": true,
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
This PR should fix the following issue: #44. IE 11 doesn't support `class`, by changing the Typescript build target to es5 the compiled output does not rely on `class` anymore.