### PR TITLE
Serve Inspector SDK over script tag

### DIFF
--- a/examples/script-tag-avo-inspector-example/index.html
+++ b/examples/script-tag-avo-inspector-example/index.html
@@ -1,0 +1,27 @@
+<html>
+    <head>
+        <title>Script Tag Inspector Example</title>
+
+        <!-- START OF INSPECTOR TAG -->
+        <script >
+            !function(){var t=window.inspector=window.inspector||[];t.methods=["trackSchemaFromEvent","trackSchema","setBatchSize","setBatchFlushSeconds"],t.factory=function(e){return function(){var r=Array.prototype.slice.call(arguments);return r.unshift(e),t.push(r),t}};for(var e=0;e<t.methods.length;e++){var r=t.methods[e];t[r]=t.factory(r)}t.load=function(){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src="https://cdn.avo.app/inspector/inspector-v1.min.js";var e=document.getElementsByTagName("script")[0];e.parentNode.insertBefore(t,e)},t._scriptVersion=1}();
+            
+            // Update the following variables to match your project.
+            inspector.__API_KEY__ = "YOUR-API-KEY";
+            inspector.__ENV__ = "dev"; // or "prod"
+            inspector.__VERSION__ = "YOUR-APP-VERSION";
+            inspector.__APP_NAME__ = "YOUR-APP-NAME";
+            
+            inspector.load();
+        </script>
+        <!-- END OF INSPECTOR TAG --> 
+
+    </head>
+    <body>
+        <h1>Script Tag Inspector Example</h1>
+        <p>
+            This example shows how to install the Avo Inspector via <code>script</code> tag.
+        </p>
+        <button onclick="window.inspector.trackSchemaFromEvent('My Event Name', {'My Property Name': 'string'})">Track Event Schema</button>
+    </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc --emitDeclarationOnly && webpack src/index.ts --mode production --resolve-extensions .ts --module-bind ts=ts-loader --define process.env.BROWSER=1 --output-filename index.js --output-library-target umd",
+    "build-for-script-tag": "tsc --emitDeclarationOnly && webpack src/browser.js --mode production --resolve-extensions .ts --module-bind ts=ts-loader --define process.env.BROWSER=1 --woutput-filename browser.js --output-library-target umd",
     "build-native": "tsc --outDir dist-native",
     "test": "jest",
     "test:browser": "BROWSER=1 jest",

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,0 +1,26 @@
+import { AvoInspector } from "./AvoInspector";
+
+if (typeof window !== "undefined") {
+  if (console !== "undefined" && window.inspector.__ENV__ == "dev") {
+    console.log("Avo Inspector: Loaded. Starting initialization...");
+  }
+  if (console !== "undefined" && window.inspector.__API_KEY__ == "MY-API-KEY") {
+    console.error("Avo Inspector: API key not provided");
+  }
+
+  const callQueue = window.inspector;
+  window.inspector = new AvoInspector({
+    apiKey: window.inspector.__API_KEY__,
+    env: window.inspector.__ENV__,
+    version: window.inspector.__VERSION__,
+    appName: window.inspector.__APP_NAME__,
+  });
+
+  callQueue.forEach((call) => {
+    const method = call[0];
+    call.shift();
+    window.inspector[method](...call);
+  });
+} else if (console !== "undefined") {
+  console.log("Avo Inspector: Window not available. Aborting.");
+}

--- a/src/script.js
+++ b/src/script.js
@@ -1,0 +1,30 @@
+!(function () {
+  var inspector = (window.inspector = window.inspector || []);
+  inspector.methods = [
+    "trackSchemaFromEvent",
+    "trackSchema",
+    "setBatchSize",
+    "setBatchFlushSeconds",
+  ];
+  inspector.factory = function (method) {
+    return function () {
+      var t = Array.prototype.slice.call(arguments);
+      t.unshift(method);
+      inspector.push(t);
+      return inspector;
+    };
+  };
+  for (var e = 0; e < inspector.methods.length; e++) {
+    var key = inspector.methods[e];
+    inspector[key] = inspector.factory(key);
+  }
+  inspector.load = function () {
+    var t = document.createElement("script");
+    t.type = "text/javascript";
+    t.async = !0;
+    t.src = "https://cdn.avo.app/inspector/inspector-v1.min.js";
+    var n = document.getElementsByTagName("script")[0];
+    n.parentNode.insertBefore(t, n);
+  };
+  inspector._scriptVersion = 1;
+})();


### PR DESCRIPTION
- `src/browser.js`: A new entry point for a build that can be served over CDN and imported via script tag
- `src/script.js`: A simple script tag that fetches the SDK from our CDN and stores calls that are made before the SDK has loaded
- `examples/script-tag-avo-inspector-example`: Example HTML file using the Inspector SDK from a script tag

The `src/browser.js` entry point bundled with `yarn build-for-script-tag` and served at https://cdn.avo.app/inspector/inspector-v1.min.js
