### PR TITLE
Export expected environment types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { AvoInspector } from "./AvoInspector";
-export { AvoInspectorEnv } from "./AvoInspectorEnv";
+export { AvoInspectorEnv, AvoInspectorEnvType, AvoInspectorEnvValueType } from "./AvoInspectorEnv";


### PR DESCRIPTION
This way we can reuse already defined types by the library instead of typing them ourselves 

```tsx
typeof AvoInspectorEnv[keyof typeof AvoInspectorEnv]
```