### PR TITLE
fix: harden Claude workflow — trust-gating, pin SHAs, security fixes

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,6 +38,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,25 +13,42 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body || '', '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body || '', '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body || '', '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        contains(github.event.issue.body || '', '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@673eb13aa77026be5c507eda12322c1a58b80f0b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
+          plugin_marketplaces: |
+            https://github.com/anthropics/claude-code.git
+          plugins: |
+            code-review@claude-code-plugins


### PR DESCRIPTION
## Summary
- Add `author_association` trust-gating (OWNER/MEMBER/COLLABORATOR only) to prevent untrusted users from triggering Claude runs
- Pin actions to immutable commit SHAs (`actions/checkout`, `anthropics/claude-code-action`)
- Remove unnecessary `id-token: write` permission (not needed for OAuth auth)
- Add null-coalescing (`|| ''`) to `contains()` checks
- Switch plugin config to YAML multiline syntax

Matches the hardened workflow from avohq/node-avo-inspector#35.

## Test plan
- [x] Verify `@claude review` still works for org members
- [x] Verify external users cannot trigger Claude runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow security controls: now requires contributors to be owners, members, or collaborators in addition to command invocation
  * Pinned all workflow action versions to specific commit hashes for enhanced stability and reproducibility
  * Removed unnecessary security permissions
  * Optimized workflow configuration structure and formatting for improved maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->