### PR TITLE
feat: gzip track payloads to cut ingestion network volume ~10x

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "ts-jest": "^29.2.4",
     "terser": "^5.31.0",
     "ts-loader": "^9.5.1",
-    "typescript": "*",
+    "typescript": ">=5.7 <6",
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4"
   }

--- a/src/AvoNetworkCallsHandler.cs.md
+++ b/src/AvoNetworkCallsHandler.cs.md
@@ -1,0 +1,51 @@
+# AvoNetworkCallsHandler
+
+## Short description
+
+Builds Inspector tracking request bodies (session-started and event-schema payloads) and POSTs them to the Avo Inspector ingestion endpoint. Owns batching guard, sampling, stream-id reconciliation, response-driven sampling-rate updates, and — as of this change — client-side gzip compression of large request bodies.
+
+## Tech stack
+
+- TypeScript, browser runtime.
+- `XMLHttpRequest` for the POST.
+- Browser-native `CompressionStream` + `TextEncoder` for gzip (no third-party dependency).
+- Collaborators: `AvoGuid` (message ids), `AvoInspector` (logging flag, network timeout), `AvoStreamId` (stream id), `EventSpecMetadata` type.
+
+## Data
+
+`BaseBody` — common envelope: `apiKey, appName, appVersion, libVersion, env, libPlatform:"web", messageId, trackingId, createdAt, sessionId, streamId, samplingRate`, optional `eventSpecMetadata`, optional `publicEncryptionKey`.
+
+`SessionStartedBody extends BaseBody` — `type:"sessionStarted"`.
+
+`EventSchemaBody extends BaseBody` — `type:"event"`, `eventId: string|null`, optional `eventName`, `eventProperties: EventProperty[]`, `avoFunction: boolean`, `eventHash: string|null`, optional `validatedBranchId`.
+
+`EventProperty` / `SchemaChild` — recursive property-schema shape with optional `failedEventIds` / `passedEventIds` validation results.
+
+`gzipMinBodyLength = 1024` — bodies shorter than this (in JS string length) are sent uncompressed.
+
+## Functional requirements
+
+- `callInspectorWithBatchBody(events, onCompleted)` — rejects re-entrant sends while one is in flight (calls back with an Error, does not send); filters out null events; reconciles stream ids; returns silently on empty list; may drop the batch by sampling; sets the `sending` guard, sends, and clears the guard in the completion callback.
+- `callInspectorImmediately(eventBody, onCompleted)` — single-event send that bypasses batching and sampling (validated events are always sent); reconciles an `"unknown"` stream id.
+- `bodyForSessionStartedCall()` / `bodyForEventSchemaCall(...)` — construct the typed bodies from instance config.
+- `fixStreamIds(events)` — replaces any `"unknown"` streamId with the first known stream id in the batch, else `AvoStreamId.streamId`.
+
+### Send path (`callInspectorApi` → `sendTrackingRequest`)
+
+1. `callInspectorApi` serializes events once: `body = JSON.stringify(events)`.
+2. **Uncompressed fast path (synchronous):** if `CompressionStream` is `undefined` OR `body.length < gzipMinBodyLength`, call `sendTrackingRequest(body, isGzipped=false, …)` and return immediately — preserving legacy timing.
+3. **Compressed path (async):** otherwise `gzip(body)` then, in the promise callback, send the compressed `Uint8Array` with `isGzipped=true` if compression succeeded, or fall back to the uncompressed string with `isGzipped=false` if `gzip` returned null.
+4. `sendTrackingRequest(body, isGzipped, onCompleted)` opens an async POST to `trackingEndpoint`, sets `Content-Type: text/plain`, adds `Content-Encoding: gzip` **only when `isGzipped`**, applies `AvoInspector.networkTimeout`, and sends the string-or-bytes body.
+5. On `onload`: non-200 → Error callback; 200 → parse JSON response (parse failure → Error callback), adopt `response.samplingRate` when it is a valid number, then `onCompleted(null)`. `onerror` / `ontimeout` produce the corresponding Error callbacks.
+
+`gzip(body)` — encodes the string to UTF-8 bytes, pipes through a `"gzip"` `CompressionStream`, concatenates the output chunks into one `Uint8Array`, and returns it. Returns `null` if anything throws.
+
+- IMPORTANT: `trackingEndpoint` is `https://api.avo.app/inspector/v1/track`.
+
+## Non-functional requirements
+
+- **Network-volume reduction:** large bodies are gzipped client-side (~6–10× smaller) to cut metered ingestion volume.
+- **Backward-compatible fallbacks, behavior-preserving:** browsers without `CompressionStream` send uncompressed *synchronously* with no `Content-Encoding` header (so they never trigger a CORS preflight); runtime compression failure falls back to the uncompressed string; sub-1 KB bodies skip gzip. In every fallback the wire shape is byte-identical to pre-change behavior.
+- **Wire-shape invariant:** a gzipped body must gunzip back to the exact original `JSON.stringify(events)` string.
+- **Preflight note:** sending `Content-Encoding: gzip` is not CORS-safelisted, so compressed POSTs are preflighted; the ingestion server must answer `OPTIONS` and decompress the body.
+- Re-entrancy guard (`sending`) prevents overlapping batch sends; `samplingRate` is mutated from server responses.

--- a/src/AvoNetworkCallsHandler.ts
+++ b/src/AvoNetworkCallsHandler.ts
@@ -68,6 +68,44 @@ export interface EventSchemaBody extends BaseBody {
   validatedBranchId?: string;
 }
 
+/** Bodies smaller than this are sent uncompressed — gzip overhead outweighs the gain. */
+const gzipMinBodyLength = 1024;
+
+/**
+ * Gzips a string body using the browser-native CompressionStream API.
+ * Returns null if compression fails for any reason.
+ */
+async function gzip(body: string): Promise<Uint8Array<ArrayBuffer> | null> {
+  try {
+    const stream = new CompressionStream("gzip");
+    const writer = stream.writable.getWriter();
+    writer.write(new TextEncoder().encode(body)).catch(() => {});
+    writer.close().catch(() => {});
+
+    const reader = stream.readable.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalLength = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      chunks.push(value);
+      totalLength += value.length;
+    }
+
+    const result = new Uint8Array(totalLength);
+    let offset = 0;
+    chunks.forEach((chunk) => {
+      result.set(chunk, offset);
+      offset += chunk.length;
+    });
+    return result;
+  } catch {
+    return null;
+  }
+}
+
 export class AvoNetworkCallsHandler {
   private readonly apiKey: string;
   private readonly envName: string;
@@ -270,16 +308,48 @@ export class AvoNetworkCallsHandler {
 
   /**
    * Core Inspector API call logic shared by batch and immediate calls.
+   *
+   * Bodies large enough to be worth it are gzipped (with Content-Encoding: gzip)
+   * to cut network volume ~10x. When CompressionStream is unavailable or
+   * compression fails, the body is sent uncompressed exactly as before —
+   * synchronously in the unavailable case, so legacy timing is preserved.
    */
   private callInspectorApi(
     events: Array<SessionStartedBody | EventSchemaBody>,
     onCompleted: (error: Error | null) => any
   ): void {
+    const body = JSON.stringify(events);
+
+    if (
+      typeof CompressionStream === "undefined" ||
+      body.length < gzipMinBodyLength
+    ) {
+      this.sendTrackingRequest(body, false, onCompleted);
+      return;
+    }
+
+    gzip(body).then((compressed) => {
+      if (compressed !== null) {
+        this.sendTrackingRequest(compressed, true, onCompleted);
+      } else {
+        this.sendTrackingRequest(body, false, onCompleted);
+      }
+    });
+  }
+
+  private sendTrackingRequest(
+    body: string | Uint8Array<ArrayBuffer>,
+    isGzipped: boolean,
+    onCompleted: (error: Error | null) => any
+  ): void {
     const xmlhttp = new XMLHttpRequest();
     xmlhttp.open("POST", AvoNetworkCallsHandler.trackingEndpoint, true);
     xmlhttp.setRequestHeader("Content-Type", "text/plain");
+    if (isGzipped) {
+      xmlhttp.setRequestHeader("Content-Encoding", "gzip");
+    }
     xmlhttp.timeout = AvoInspector.networkTimeout;
-    xmlhttp.send(JSON.stringify(events));
+    xmlhttp.send(body);
 
     xmlhttp.onload = () => {
       if (xmlhttp.status !== 200) {

--- a/src/AvoNetworkCallsHandler.ts
+++ b/src/AvoNetworkCallsHandler.ts
@@ -75,7 +75,7 @@ const gzipMinBodyLength = 1024;
  * Gzips a string body using the browser-native CompressionStream API.
  * Returns null if compression fails for any reason.
  */
-async function gzip(body: string): Promise<Uint8Array<ArrayBuffer> | null> {
+async function gzip(body: string): Promise<Uint8Array | null> {
   try {
     const stream = new CompressionStream("gzip");
     const writer = stream.writable.getWriter();
@@ -338,7 +338,7 @@ export class AvoNetworkCallsHandler {
   }
 
   private sendTrackingRequest(
-    body: string | Uint8Array<ArrayBuffer>,
+    body: string | Uint8Array,
     isGzipped: boolean,
     onCompleted: (error: Error | null) => any
   ): void {
@@ -349,7 +349,7 @@ export class AvoNetworkCallsHandler {
       xmlhttp.setRequestHeader("Content-Encoding", "gzip");
     }
     xmlhttp.timeout = AvoInspector.networkTimeout;
-    xmlhttp.send(body);
+    xmlhttp.send(body as XMLHttpRequestBodyInit);
 
     xmlhttp.onload = () => {
       if (xmlhttp.status !== 200) {

--- a/src/__tests__/NetworkCallsHandlerGzip_test.ts
+++ b/src/__tests__/NetworkCallsHandlerGzip_test.ts
@@ -18,10 +18,16 @@ const inspectorVersion = process.env.npm_package_version || "";
 
 const { apiKey, env, version } = defaultOptions;
 
+let streamIdSpy: jest.SpyInstance;
+
 beforeAll(() => {
-  jest
+  streamIdSpy = jest
     .spyOn(AvoStreamId as any, "streamId", "get")
     .mockImplementation(() => "stream-id");
+});
+
+afterAll(() => {
+  streamIdSpy.mockRestore();
 });
 
 function newHandler(): AvoNetworkCallsHandler {

--- a/src/__tests__/NetworkCallsHandlerGzip_test.ts
+++ b/src/__tests__/NetworkCallsHandlerGzip_test.ts
@@ -178,6 +178,93 @@ describe("NetworkCallsHandler gzip compression", () => {
       xhrMock.onload();
       expect(customCallback).toHaveBeenCalledWith(null);
     });
+
+    test("gzipped sends happen asynchronously (not synchronously)", async () => {
+      const handler = newHandler();
+
+      handler.callInspectorWithBatchBody(largeEvents(handler), customCallback);
+
+      // The gzip branch awaits CompressionStream, so nothing is sent on the
+      // synchronous tick — the mirror of the unavailable-branch sync send.
+      expect(xhrMock.send).not.toHaveBeenCalled();
+
+      // Drain the pending async send so it can't leak into the next test.
+      await waitFor(() => xhrMock.send.mock.calls.length > 0);
+    });
+
+    test("callInspectorImmediately gzips a large event body", async () => {
+      const handler = newHandler();
+      const eventBody = handler.bodyForEventSchemaCall(
+        "big immediate event",
+        Array.from({ length: 40 }, (_, i) => ({
+          propertyName: `property number ${i}`,
+          propertyType: "string"
+        })),
+        null,
+        null
+      );
+      const expectedJson = JSON.stringify([eventBody]);
+      expect(expectedJson.length).toBeGreaterThan(1024);
+
+      handler.callInspectorImmediately(eventBody, customCallback);
+
+      await waitFor(() => xhrMock.send.mock.calls.length > 0);
+
+      expect(sentHeaders()["Content-Encoding"]).toBe("gzip");
+      expect(gunzipToString(sentBody())).toBe(expectedJson);
+
+      xhrMock.onload();
+      expect(customCallback).toHaveBeenCalledWith(null);
+    });
+
+    test("adopts samplingRate from the response after a gzipped send", async () => {
+      const randomSpy = jest.spyOn(Math, "random").mockReturnValue(0.5);
+      const originalResponse = xhrMock.response;
+      try {
+        const handler = newHandler();
+
+        // samplingRate starts at 1.0, so 0.5 > 1.0 is false — first batch sends.
+        handler.callInspectorWithBatchBody(largeEvents(handler), customCallback);
+        await waitFor(() => xhrMock.send.mock.calls.length > 0);
+
+        xhrMock.response = JSON.stringify({ samplingRate: 0 });
+        xhrMock.onload();
+        expect(customCallback).toHaveBeenCalledWith(null);
+
+        // samplingRate is now 0, so 0.5 > 0 is true — the next batch is dropped
+        // before reaching the network (synchronous drop, no new send).
+        const sendsBefore = xhrMock.send.mock.calls.length;
+        handler.callInspectorWithBatchBody(largeEvents(handler), customCallback);
+        expect(xhrMock.send.mock.calls.length).toBe(sendsBefore);
+      } finally {
+        xhrMock.response = originalResponse;
+        randomSpy.mockRestore();
+      }
+    });
+
+    test("invokes the callback with an error on network error after a gzipped send", async () => {
+      const handler = newHandler();
+
+      handler.callInspectorWithBatchBody(largeEvents(handler), customCallback);
+      await waitFor(() => xhrMock.send.mock.calls.length > 0);
+
+      xhrMock.onerror();
+
+      expect(customCallback).toHaveBeenCalledTimes(1);
+      expect(customCallback).toHaveBeenCalledWith(new Error("Request failed"));
+    });
+
+    test("invokes the callback with an error on timeout after a gzipped send", async () => {
+      const handler = newHandler();
+
+      handler.callInspectorWithBatchBody(largeEvents(handler), customCallback);
+      await waitFor(() => xhrMock.send.mock.calls.length > 0);
+
+      xhrMock.ontimeout();
+
+      expect(customCallback).toHaveBeenCalledTimes(1);
+      expect(customCallback).toHaveBeenCalledWith(new Error("Request timed out"));
+    });
   });
 
   describe("when CompressionStream is unavailable", () => {

--- a/src/__tests__/NetworkCallsHandlerGzip_test.ts
+++ b/src/__tests__/NetworkCallsHandlerGzip_test.ts
@@ -1,0 +1,238 @@
+import * as zlib from "zlib";
+
+import { AvoNetworkCallsHandler } from "../AvoNetworkCallsHandler";
+import { AvoNetworkCallsHandlerLite } from "../lite/AvoNetworkCallsHandlerLite";
+import { AvoStreamId } from "../AvoStreamId";
+
+import xhrMock from "../__mocks__/xhr";
+
+import { defaultOptions } from "./constants";
+
+// Real web-standard CompressionStream implementation from Node, installed
+// into the jsdom test environment so tests exercise real gzip compression.
+const {
+  CompressionStream: NodeCompressionStream
+} = require("node:stream/web");
+
+const inspectorVersion = process.env.npm_package_version || "";
+
+const { apiKey, env, version } = defaultOptions;
+
+beforeAll(() => {
+  jest
+    .spyOn(AvoStreamId as any, "streamId", "get")
+    .mockImplementation(() => "stream-id");
+});
+
+function newHandler(): AvoNetworkCallsHandler {
+  return new AvoNetworkCallsHandler(apiKey, env, "", version, inspectorVersion);
+}
+
+function newLiteHandler(): AvoNetworkCallsHandlerLite {
+  return new AvoNetworkCallsHandlerLite(
+    apiKey,
+    env,
+    "",
+    version,
+    inspectorVersion
+  );
+}
+
+// Builds a batch whose JSON body is comfortably above the gzip size threshold.
+function largeEvents(handler: {
+  bodyForEventSchemaCall: (
+    name: string,
+    props: Array<{ propertyName: string; propertyType: string }>,
+    eventId: string | null,
+    eventHash: string | null
+  ) => any;
+}): any[] {
+  const eventProperties = Array.from({ length: 30 }, (_, i) => ({
+    propertyName: `property number ${i}`,
+    propertyType: "string"
+  }));
+  return Array.from({ length: 5 }, (_, i) =>
+    handler.bodyForEventSchemaCall(`event ${i}`, eventProperties, null, null)
+  );
+}
+
+// Builds a batch whose JSON body is below the gzip size threshold (1024 bytes).
+function smallEvents(handler: {
+  bodyForSessionStartedCall: () => any;
+}): any[] {
+  return [handler.bodyForSessionStartedCall()];
+}
+
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs: number = 1000
+): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+function sentBody(): any {
+  expect(xhrMock.send).toHaveBeenCalledTimes(1);
+  return xhrMock.send.mock.calls[0][0];
+}
+
+function sentHeaders(): { [name: string]: string } {
+  const headers: { [name: string]: string } = {};
+  xhrMock.setRequestHeader.mock.calls.forEach(
+    ([name, value]: [string, string]) => {
+      headers[name] = value;
+    }
+  );
+  return headers;
+}
+
+function gunzipToString(body: Uint8Array): string {
+  return zlib.gunzipSync(Buffer.from(body)).toString("utf-8");
+}
+
+describe("NetworkCallsHandler gzip compression", () => {
+  const customCallback = jest.fn();
+
+  beforeEach(() => {
+    (globalThis as any).CompressionStream = NodeCompressionStream;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).CompressionStream;
+    jest.clearAllMocks();
+  });
+
+  describe("when CompressionStream is available", () => {
+    test("large payloads are gzipped and sent with Content-Encoding: gzip", async () => {
+      const handler = newHandler();
+      const events = largeEvents(handler);
+      const expectedJson = JSON.stringify(events);
+      expect(expectedJson.length).toBeGreaterThan(1024);
+
+      handler.callInspectorWithBatchBody(events, customCallback);
+
+      await waitFor(() => xhrMock.send.mock.calls.length > 0);
+
+      const headers = sentHeaders();
+      expect(headers["Content-Type"]).toBe("text/plain");
+      expect(headers["Content-Encoding"]).toBe("gzip");
+
+      const body = sentBody();
+      expect(typeof body).not.toBe("string");
+      expect(gunzipToString(body)).toBe(expectedJson);
+      expect(body.length).toBeLessThan(expectedJson.length);
+    });
+
+    test("response handling still works after a gzipped send", async () => {
+      const handler = newHandler();
+
+      handler.callInspectorWithBatchBody(largeEvents(handler), customCallback);
+
+      await waitFor(() => xhrMock.send.mock.calls.length > 0);
+
+      xhrMock.onload();
+
+      expect(customCallback).toHaveBeenCalledTimes(1);
+      expect(customCallback).toHaveBeenCalledWith(null);
+    });
+
+    test("small payloads below the threshold are sent uncompressed", () => {
+      const handler = newHandler();
+      const events = smallEvents(handler);
+      const expectedJson = JSON.stringify(events);
+      expect(expectedJson.length).toBeLessThan(1024);
+
+      handler.callInspectorWithBatchBody(events, customCallback);
+
+      expect(xhrMock.send).toHaveBeenCalledTimes(1);
+      expect(xhrMock.send).toHaveBeenCalledWith(expectedJson);
+      expect(sentHeaders()["Content-Encoding"]).toBeUndefined();
+    });
+
+    test("falls back to uncompressed when compression fails", async () => {
+      (globalThis as any).CompressionStream = function () {
+        throw new Error("compression broken");
+      };
+
+      const handler = newHandler();
+      const events = largeEvents(handler);
+
+      handler.callInspectorWithBatchBody(events, customCallback);
+
+      await waitFor(() => xhrMock.send.mock.calls.length > 0);
+
+      expect(xhrMock.send).toHaveBeenCalledWith(JSON.stringify(events));
+      expect(sentHeaders()["Content-Encoding"]).toBeUndefined();
+
+      xhrMock.onload();
+      expect(customCallback).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe("when CompressionStream is unavailable", () => {
+    test("large payloads are sent uncompressed synchronously without Content-Encoding", () => {
+      delete (globalThis as any).CompressionStream;
+
+      const handler = newHandler();
+      const events = largeEvents(handler);
+
+      handler.callInspectorWithBatchBody(events, customCallback);
+
+      // Synchronous send — no await needed, preserving pre-gzip behavior.
+      expect(xhrMock.send).toHaveBeenCalledTimes(1);
+      expect(xhrMock.send).toHaveBeenCalledWith(JSON.stringify(events));
+      expect(sentHeaders()["Content-Encoding"]).toBeUndefined();
+
+      xhrMock.onload();
+      expect(customCallback).toHaveBeenCalledWith(null);
+    });
+  });
+});
+
+describe("NetworkCallsHandlerLite gzip compression", () => {
+  const customCallback = jest.fn();
+
+  beforeEach(() => {
+    (globalThis as any).CompressionStream = NodeCompressionStream;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).CompressionStream;
+    jest.clearAllMocks();
+  });
+
+  test("large payloads are gzipped and sent with Content-Encoding: gzip", async () => {
+    const handler = newLiteHandler();
+    const events = largeEvents(handler);
+    const expectedJson = JSON.stringify(events);
+    expect(expectedJson.length).toBeGreaterThan(1024);
+
+    handler.callInspectorWithBatchBody(events, customCallback);
+
+    await waitFor(() => xhrMock.send.mock.calls.length > 0);
+
+    const headers = sentHeaders();
+    expect(headers["Content-Type"]).toBe("text/plain");
+    expect(headers["Content-Encoding"]).toBe("gzip");
+
+    expect(gunzipToString(sentBody())).toBe(expectedJson);
+  });
+
+  test("sends uncompressed without Content-Encoding when CompressionStream is unavailable", () => {
+    delete (globalThis as any).CompressionStream;
+
+    const handler = newLiteHandler();
+    const events = largeEvents(handler);
+
+    handler.callInspectorWithBatchBody(events, customCallback);
+
+    expect(xhrMock.send).toHaveBeenCalledTimes(1);
+    expect(xhrMock.send).toHaveBeenCalledWith(JSON.stringify(events));
+    expect(sentHeaders()["Content-Encoding"]).toBeUndefined();
+  });
+});

--- a/src/lite/AvoNetworkCallsHandlerLite.cs.md
+++ b/src/lite/AvoNetworkCallsHandlerLite.cs.md
@@ -1,0 +1,37 @@
+# AvoNetworkCallsHandlerLite
+
+## Short description
+
+Lite-bundle copy of `AvoNetworkCallsHandler` (class `AvoNetworkCallsHandlerLite`), kept textually in sync with the full handler. Builds Inspector tracking request bodies and POSTs them to the Avo Inspector ingestion endpoint, with client-side gzip compression of large bodies. Maintained under a strict gzipped-bundle size budget (≤ 7 KB; currently ~5.5 KB).
+
+## Tech stack
+
+- TypeScript, browser runtime.
+- `XMLHttpRequest` for the POST.
+- Browser-native `CompressionStream` + `TextEncoder` for gzip (no third-party dependency).
+- Collaborators mirror the full handler (`AvoGuid`, `AvoInspector`, `AvoStreamId`, `EventSpecMetadata`).
+
+## Data
+
+Same body/type shapes as the full handler: `BaseBody`, `SessionStartedBody`, `EventSchemaBody`, `EventProperty` / `SchemaChild`. `gzipMinBodyLength = 1024` — sub-1 KB bodies are sent uncompressed.
+
+## Functional requirements
+
+Mirrors `AvoNetworkCallsHandler`. Public surface: `callInspectorWithBatchBody`, `callInspectorImmediately`, `bodyForSessionStartedCall`, `bodyForEventSchemaCall`, with the same re-entrancy guard, null filtering, stream-id reconciliation, empty-list short-circuit, and sampling drop.
+
+### Send path (`callInspectorApi` → `sendTrackingRequest`)
+
+1. Serialize once: `body = JSON.stringify(events)`.
+2. **Uncompressed fast path (synchronous):** if `CompressionStream` is `undefined` OR `body.length < gzipMinBodyLength`, send `body` with `isGzipped=false` and return immediately.
+3. **Compressed path (async):** otherwise `gzip(body)`; on success send the `Uint8Array` with `isGzipped=true`, on null fall back to the uncompressed string with `isGzipped=false`.
+4. `sendTrackingRequest` sets `Content-Type: text/plain`, adds `Content-Encoding: gzip` only when gzipped, applies `AvoInspector.networkTimeout`, POSTs to `trackingEndpoint`.
+5. `onload`: non-200 → Error; 200 → parse response (parse failure → Error), adopt valid numeric `response.samplingRate`, then `onCompleted(null)`. `onerror` / `ontimeout` → corresponding Errors.
+
+`gzip(body)` — UTF-8 encode → `"gzip"` `CompressionStream` → concatenated `Uint8Array`; returns `null` on any throw.
+
+## Non-functional requirements
+
+- **Textual-sync invariant:** the gzip helper, threshold, and send path are byte-for-byte the same logic as `AvoNetworkCallsHandler`; `verify:lite-sync` enforces the allowed drift baseline and `check:lite-size` enforces the bundle budget.
+- **Backward-compatible fallbacks:** no `CompressionStream` → synchronous uncompressed send, no `Content-Encoding` (no CORS preflight); runtime failure → uncompressed fallback; sub-1 KB → uncompressed.
+- **Wire-shape invariant:** a gzipped body must gunzip back to the exact original `JSON.stringify(events)` string.
+- **Preflight note:** `Content-Encoding: gzip` is not CORS-safelisted; the server must answer the preflight `OPTIONS` and decompress the body.

--- a/src/lite/AvoNetworkCallsHandlerLite.ts
+++ b/src/lite/AvoNetworkCallsHandlerLite.ts
@@ -65,6 +65,44 @@ export interface EventSchemaBody extends BaseBody {
   validatedBranchId?: string;
 }
 
+/** Bodies smaller than this are sent uncompressed — gzip overhead outweighs the gain. */
+const gzipMinBodyLength = 1024;
+
+/**
+ * Gzips a string body using the browser-native CompressionStream API.
+ * Returns null if compression fails for any reason.
+ */
+async function gzip(body: string): Promise<Uint8Array<ArrayBuffer> | null> {
+  try {
+    const stream = new CompressionStream("gzip");
+    const writer = stream.writable.getWriter();
+    writer.write(new TextEncoder().encode(body)).catch(() => {});
+    writer.close().catch(() => {});
+
+    const reader = stream.readable.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalLength = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      chunks.push(value);
+      totalLength += value.length;
+    }
+
+    const result = new Uint8Array(totalLength);
+    let offset = 0;
+    chunks.forEach((chunk) => {
+      result.set(chunk, offset);
+      offset += chunk.length;
+    });
+    return result;
+  } catch {
+    return null;
+  }
+}
+
 export class AvoNetworkCallsHandlerLite {
   private readonly apiKey: string;
   private readonly envName: string;
@@ -238,16 +276,48 @@ export class AvoNetworkCallsHandlerLite {
 
   /**
    * Core Inspector API call logic shared by batch and immediate calls.
+   *
+   * Bodies large enough to be worth it are gzipped (with Content-Encoding: gzip)
+   * to cut network volume ~10x. When CompressionStream is unavailable or
+   * compression fails, the body is sent uncompressed exactly as before —
+   * synchronously in the unavailable case, so legacy timing is preserved.
    */
   private callInspectorApi(
     events: Array<SessionStartedBody | EventSchemaBody>,
     onCompleted: (error: Error | null) => any
   ): void {
+    const body = JSON.stringify(events);
+
+    if (
+      typeof CompressionStream === "undefined" ||
+      body.length < gzipMinBodyLength
+    ) {
+      this.sendTrackingRequest(body, false, onCompleted);
+      return;
+    }
+
+    gzip(body).then((compressed) => {
+      if (compressed !== null) {
+        this.sendTrackingRequest(compressed, true, onCompleted);
+      } else {
+        this.sendTrackingRequest(body, false, onCompleted);
+      }
+    });
+  }
+
+  private sendTrackingRequest(
+    body: string | Uint8Array<ArrayBuffer>,
+    isGzipped: boolean,
+    onCompleted: (error: Error | null) => any
+  ): void {
     const xmlhttp = new XMLHttpRequest();
     xmlhttp.open("POST", AvoNetworkCallsHandlerLite.trackingEndpoint, true);
     xmlhttp.setRequestHeader("Content-Type", "text/plain");
+    if (isGzipped) {
+      xmlhttp.setRequestHeader("Content-Encoding", "gzip");
+    }
     xmlhttp.timeout = AvoInspector.networkTimeout;
-    xmlhttp.send(JSON.stringify(events));
+    xmlhttp.send(body);
 
     xmlhttp.onload = () => {
       if (xmlhttp.status !== 200) {

--- a/src/lite/AvoNetworkCallsHandlerLite.ts
+++ b/src/lite/AvoNetworkCallsHandlerLite.ts
@@ -72,7 +72,7 @@ const gzipMinBodyLength = 1024;
  * Gzips a string body using the browser-native CompressionStream API.
  * Returns null if compression fails for any reason.
  */
-async function gzip(body: string): Promise<Uint8Array<ArrayBuffer> | null> {
+async function gzip(body: string): Promise<Uint8Array | null> {
   try {
     const stream = new CompressionStream("gzip");
     const writer = stream.writable.getWriter();
@@ -306,7 +306,7 @@ export class AvoNetworkCallsHandlerLite {
   }
 
   private sendTrackingRequest(
-    body: string | Uint8Array<ArrayBuffer>,
+    body: string | Uint8Array,
     isGzipped: boolean,
     onCompleted: (error: Error | null) => any
   ): void {
@@ -317,7 +317,7 @@ export class AvoNetworkCallsHandlerLite {
       xmlhttp.setRequestHeader("Content-Encoding", "gzip");
     }
     xmlhttp.timeout = AvoInspector.networkTimeout;
-    xmlhttp.send(body);
+    xmlhttp.send(body as XMLHttpRequestBodyInit);
 
     xmlhttp.onload = () => {
       if (xmlhttp.status !== 200) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5163,7 +5163,7 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
-typescript@*:
+"typescript@>=5.7 <6":
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==


### PR DESCRIPTION
## Why

Inspector ingestion (`/inspector/v1/track`) is billed per GB at the L7 load balancer (~€1,450/mo). Analytics JSON batches compress ~6–10x (a real 9.4 KB event payload gzips to 1.6 KB), so compressing request bodies client-side drops that line item toward ~€150–250/mo as SDK adoption ramps.

## What

Both network handlers (`AvoNetworkCallsHandler` and the lite copy, kept textually in sync):

- Bodies **≥ 1 KB** are gzipped with the browser-native `CompressionStream` API and sent with `Content-Encoding: gzip` (Content-Type stays `text/plain`). No new dependencies; lite bundle stays at 5.5 KB gzipped (limit 7 KB).
- **Fallbacks preserve today's behavior exactly:**
  - No `CompressionStream` (pre-2023 browsers) → uncompressed string sent *synchronously*, no `Content-Encoding` header — these browsers can never trigger a CORS preflight, so nothing can break for them.
  - Compression throws at runtime → uncompressed fallback.
  - Body < 1 KB → uncompressed (gzip overhead isn't worth it).

## Tests

New `NetworkCallsHandlerGzip_test.ts` (7 tests) uses Node's real web-standard `CompressionStream` — not a fake — and verifies the sent bytes **gunzip back to the exact original JSON** via `zlib.gunzipSync`, plus the header, the size threshold, both fallback paths, response/callback handling after the async send, and the lite handler.

Full sweep: 356/356 tests pass, `tsc --noEmit` clean, build succeeds, `verify:lite-sync` passes (drift back at the 53-line baseline), `check:lite-size` passes.

## ⚠️ Release gate — do not publish to npm yet

`Content-Encoding` is not a CORS-safelisted request header, so browsers will preflight the POST. The ingestion server must answer `OPTIONS /inspector/v1/track` (allow `content-type, content-encoding`, ACAO `*`, long `Access-Control-Max-Age`) **before** this ships in a release. Server-side body decompression is already live (body-parser `inflate: true`, verified via curl). Merging this PR is safe; the npm publish is what's gated on the server deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request payloads are now automatically gzip-compressed for large payloads, with fallback to uncompressed format when compression is unavailable.

* **Tests**
  * Added comprehensive test suite validating gzip compression behavior across payload sizes and failure scenarios, including fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->