### PR TITLE
Release 3.2.0 (gzip support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - Unreleased
+
+### Added
+
+- **Gzip compression of track payloads**: Track request bodies of at least 1 KB are now compressed with the browser-native `CompressionStream` API and sent with the `Content-Encoding: gzip` header, cutting ingestion network volume by roughly 10x.
+  - Smaller bodies (< 1 KB) are sent uncompressed, since gzip overhead would outweigh the gain.
+  - When `CompressionStream` is unavailable (pre-2023 browsers) or compression fails, the body is sent uncompressed exactly as before — synchronously in the unavailable case — so legacy behavior is preserved and no CORS preflight is triggered for old browsers.
+  - Applied to both the full build (`AvoNetworkCallsHandler`) and the lite build (`AvoNetworkCallsHandlerLite`).
+
 ## [3.1.0] - 2026-03-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.2.0] - Unreleased
+## [3.2.0] - 2026-06-22
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avo-inspector",
-  "version": "3.2.0-alpha.1",
+  "version": "3.2.0",
   "description": "",
   "main": "dist/index.js",
   "browser": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avo-inspector",
-  "version": "3.1.0-alpha.2",
+  "version": "3.2.0-alpha.1",
   "description": "",
   "main": "dist/index.js",
   "browser": "dist/index.js",


### PR DESCRIPTION
## What

Prepares the **3.2.0** release for dogfooding on the `alpha` dist-tag, folding in the gzip track-payload compression that merged via #212 but was never version-bumped or added to the CHANGELOG.

- Bump version `3.1.0-alpha.2` → `3.2.0-alpha.1`
- Add `## [3.2.0]` CHANGELOG section documenting gzip compression

## Why

npm `latest` is still **3.0.1**. Two things have stacked up unreleased on top of it:

1. **3.1.0 (lite entry point)** — only ever shipped to the `alpha` tag, never promoted to `latest`.
2. **gzip support (#212)** — merged with no version bump and no CHANGELOG entry, so it's entirely unpublished.

This branch packages the gzip work as a new minor (3.2.0) for alpha dogfooding. When dogfooding succeeds, we date + bump the `[3.2.0]` heading to stable and publish to `latest` — at which point 3.0.1 users receive both the lite (3.1.0) and gzip (3.2.0) work, both of which the retained CHANGELOG sections document.

## Gzip behavior (from #212)

- Track bodies ≥ 1 KB compressed via browser-native `CompressionStream` + `Content-Encoding: gzip` (~10x less ingestion volume)
- Bodies < 1 KB sent uncompressed (overhead outweighs gain)
- `CompressionStream` unavailable (pre-2023 browsers) or compression failure → uncompressed fallback, synchronous, no CORS preflight
- Applied to both full (`AvoNetworkCallsHandler`) and lite (`AvoNetworkCallsHandlerLite`) builds

## Dogfooding

```bash
npm publish --tag alpha     # prepublishOnly runs build + lite-sync + size + browser tests
npm install avo-inspector@alpha   # -> 3.2.0-alpha.1
```

> Note: the `[3.2.0]` CHANGELOG heading is intentionally left as `- Unreleased`; it gets dated at the stable cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic gzip compression for track payloads 1 KB or larger, reducing request sizes and improving performance. Smaller payloads remain uncompressed, with automatic fallback to uncompressed if compression is unavailable. Available in both standard and lite builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->